### PR TITLE
feature: smboot takes command line arguments using boost program options instead of tclap

### DIFF
--- a/src/standalone/SM_boot.cxx
+++ b/src/standalone/SM_boot.cxx
@@ -324,8 +324,8 @@ int main(int argc, char** argv) {
     // parse command line
     boost::program_options::store(boost::program_options::parse_command_line(argc, argv, commandLineOptions), commandLineVM);
   } catch(const boost::program_options::error &ex) {
-    fprintf(stderr, "Caught exception while parsing command line: %s \n", ex.what());       
-    exit(EXIT_FAILURE); 
+    fprintf(stderr, "Caught exception while parsing command line: %s \nTerminating SM_boot\n", ex.what());       
+    return -1;
   }
 
   // Check for non default config file
@@ -340,8 +340,8 @@ int main(int argc, char** argv) {
     // parse config file
     configFileVM = loadConfig(configFile, fileOptions);
   } catch(const boost::program_options::error &ex) {
-    fprintf(stdout, "Caught exception in function loadConfig(): %s \n", ex.what());        
-    exit(EXIT_FAILURE);   
+    fprintf(stdout, "Caught exception in function loadConfig(): %s \nTerminating SM_boot\n", ex.what());        
+    return -1;
   }
 
   // Look at the config file and command line and see if we should change the parameters from their default values

--- a/src/standalone/SM_boot.cxx
+++ b/src/standalone/SM_boot.cxx
@@ -65,6 +65,84 @@ boost::program_options::variables_map loadConfig(std::string const & configFileN
   return vm;
 }
 
+// // ====================================================================================================
+// // Function to set the parameter by parsing the command line. In particular, we ensure that the command line default does not override config options obtained from the config file.
+// void setParam(void * param, std::string paramString, boost::program_options::variables_map vm, bool param_from_config) {
+//   
+//   // Set parameter but make sure that the command line default does not override config options obtained from the config file. Every parameter must go through this nested if statement sequence.
+//   
+//   // Set parameter
+//   if(vm.count(paramString)) {
+//     // The parameter exists, but was it defaulted?
+//     if(vm[paramString].defaulted()) {
+//       // We have a defaulted parameter, but do we have a config option obtained from the config file?
+//       if(param_from_config) {
+// 	// We have a config option obtained from the config file. Do nothing
+// 	syslog(LOG_INFO, "Setting %s to (CONFIG FILE)\n", paramString);
+// 	return;
+//       } else {
+// 	// We do not have a config option obtained from the config file. Our default can be used.
+// 	*param = vm[paramString].as<typeof(*param)>();	
+// 	syslog(LOG_INFO, "Setting %s to (DEFAULT)\n", paramString);
+// 	return;
+//       } 
+//     } else { 
+//       // We have a non-defaulted parameter option set from the command line! This trumps everything
+//       *param = vm[paramString].as<typeof(*param)>();      
+//       syslog(LOG_INFO, "Setting %s to (COMMAND LINE)\n", paramString);
+//       return;
+//     }
+//   }
+//   
+// }
+
+// Function to add parameters/options. Saves a few lines of code. Not necessary.
+template <class T>
+void setOption(boost::program_options::options_description * fileOptions, boost::program_options::options_description * commandLineOptions, std::string paramName, std::string paramDesc, T /*param*/) {
+  // It's hacky to pass the parameter to this function solely to use its type. May be a better way
+  (*fileOptions).add_options()
+    (paramName.c_str(),
+     boost::program_options::value<T>(),
+     paramDesc.c_str());
+  (*commandLineOptions).add_options()
+    (paramName.c_str(),
+     boost::program_options::value<T>(),
+     paramDesc.c_str());
+}
+
+template <class T>
+// Log what the parameter value was set to and where it came fro
+void paramLog(std::string paramName, T paramValue, std::string where) {
+  std::stringstream ss;
+  std::string str;
+  ss << paramValue;
+  ss >> str;
+  syslog(LOG_INFO, "%s was set to: %s %s\n", paramName.c_str(), str.c_str(), where.c_str()); 
+}
+
+template <class T>
+void setParamValue(T * param, std::string paramName, boost::program_options::variables_map configFileVM, boost::program_options::variables_map commandLineVM) {
+  // The order of precedence is: command line specified, config file specified, default
+  
+  if(commandLineVM.count(paramName)) {
+    // parameter value specified at command line
+    paramLog(paramName, commandLineVM[paramName].as<T>(), "(COMMAND LINE)");
+    *param = commandLineVM[paramName].as<T>();
+    return;
+  }
+      
+  if(configFileVM.count(paramName)) {
+    // parameter value specified in config file
+    paramLog(paramName, configFileVM[paramName].as<T>(), "(CONFIG FILE)");
+    *param = configFileVM[paramName].as<T>();
+    return;
+  }
+
+  // Parameter not specified anywhere, keep default
+  paramLog(paramName, *param, "(DEFAULT)");
+  return;
+
+}
 // ====================================================================================================
 long us_difftime(struct timespec cur, struct timespec end){ 
   return ( (end.tv_sec  - cur.tv_sec )*SEC_IN_US + 
@@ -255,74 +333,212 @@ int main(int argc, char** argv) {
   close(STDOUT_FILENO);
   close(STDERR_FILENO);
 
-  
   // ============================================================================
-  // Read from configuration file and set up parameters
-  syslog(LOG_INFO,"Reading from config file now\n");
+  // parameters to get from command line or config file
   int polltime_in_seconds = DEFAULT_POLLTIME_IN_SECONDS;
   bool powerupCMuC = true;
   int powerupTime = DEFAULT_POWERUP_TIME;
   bool sensorsThroughZynq = DEFAULT_SENSORS_THROUGH_ZYNQ;
+  // These "sister" variables, if true, ensure that the command line default does not override the config file 
+//  bool polltime_from_config    = false;
+//  bool powerupCMuC_from_config = false;
+//  bool powerupTime_from_config = false;
+//  bool sTZ_from_config         = false;  
 
-  // fileOptions is for parsing config files
-  boost::program_options::options_description fileOptions{"File"};
-  //sigh... with boost comes compilcated c++ magic
-  fileOptions.add_options() 
-    ("polltime", 
-     boost::program_options::value<int>()->default_value(DEFAULT_POLLTIME_IN_SECONDS), 
-     "polling interval")
-    ("cm_powerup",
-     boost::program_options::value<bool>()->default_value(true), 
-     "power up CM uC")
-    ("cm_powerup_time",
-     boost::program_options::value<int>()->default_value(DEFAULT_POWERUP_TIME), 
-     "uC powerup wait time")
-    ("sensorsThroughZynq",
-     boost::program_options::value<bool>()->default_value(DEFAULT_SENSORS_THROUGH_ZYNQ),
-     "read sensor data through zynq");
-
-  boost::program_options::variables_map configOptions;  
-  try{
-    configOptions = loadConfig(configFile.getValue(),fileOptions);
-    // Check for information in configOptions
-    if(configOptions.count("polltime")) {
-      polltime_in_seconds = configOptions["polltime"].as<int>();
-    }  
-    syslog(LOG_INFO,
-	   "Setting poll time to %d seconds (%s)\n",
-	   polltime_in_seconds, 
-	   configOptions.count("polltime") ? "CONFIG FILE" : "DEFAULT");
-    if(configOptions.count("cm_powerup")) {
-      powerupCMuC = configOptions["cm_powerup"].as<bool>();
-    }  
-    syslog(LOG_INFO,
-	   "%s up CM uC @ boot (%s)\n",
-	   powerupCMuC ? "Powering" : "Not powering",
-	   configOptions.count("polltime") ? "CONFIG FILE" : "DEFAULT");
-    if(configOptions.count("cm_powerup_time")) {
-      powerupTime = configOptions["cm_powerup_time"].as<int>();
-    }  
-    syslog(LOG_INFO,
-	   "Setting uC power-up time to %d seconds (%s)\n",
-	   powerupTime,
-	   configOptions.count("cm_powerup_time") ? "CONFIG FILE" : "DEFAULT");
-    if(configOptions.count("sensorsThroughZynq")) {
-      sensorsThroughZynq = configOptions["sensorsThroughZynq"].as<bool>();
-    }
-    syslog(LOG_INFO,
-	   "%s sensors through Zynq (%s)\n",
-	   sensorsThroughZynq ? "Reading" : "Not reading",
-	   configOptions.count("sensorsThroughZynq") ? "CONFIG_FILE" : "DEFAULT");
-
-    //    if(configOptions.count("sensorsThroughZynq")) {
-    //   syslog(LOG_INFO, "count of sensorsThroughZynq is somehow nonzero\n");
-    //  }
-
-  }catch(const boost::program_options::error &ex){
-    syslog(LOG_INFO, "Caught exception in function loadConfig(): %s \n", ex.what());    
+  // =========================
+  // parse command line and config file to set parameters
+  boost::program_options::options_description fileOptions{"File"}; // for parsing config file
+  boost::program_options::options_description commandLineOptions{"Options"}; // for parsing command line
+  setOption(&fileOptions, &commandLineOptions, "polltime"          , "polling interval"             , polltime_in_seconds);
+  setOption(&fileOptions, &commandLineOptions, "cm_powerup"        , "power up CM uC"               , powerupCMuC);
+  setOption(&fileOptions, &commandLineOptions, "cm_powerup_time"   , "uC power up wait time"        , powerupTime);
+  setOption(&fileOptions, &commandLineOptions, "sensorsThroughZynq", "read sensor data through Zynq", sensorsThroughZynq);
+  boost::program_options::variables_map configFileVM; // for parsing config file
+  boost::program_options::variables_map commandLineVM; // for parsing command line
+  syslog(LOG_INFO, "Reading from config file now\n");
+  std::string myFile = DEFAULT_CONFIG_FILE;
+  try {
+    // parse config file
+    configFileVM = loadConfig(myFile, fileOptions);
+  } catch(const boost::program_options::error &ex) {
+    syslog(LOG_INFO, "Caught exception in function loadConfig(): %s \n", ex.what());        
+  }
+  syslog(LOG_INFO, "Parsing command line now\n");
+  try {
+    // parse command line
+    boost::program_options::store(boost::program_options::parse_command_line(argc, argv, commandLineOptions), commandLineVM);
+  } catch(const boost::program_options::error &ex) {
+    syslog(LOG_INFO, "Caught exception while parsing command line: %s \n", ex.what());        
   }
 
+  // Look at the config file and command line and see if we should change the parameters from their default values
+  setParamValue(&polltime_in_seconds, "polltime"          , configFileVM, commandLineVM);
+  setParamValue(&powerupCMuC        , "cm_powerup"        , configFileVM, commandLineVM);
+  setParamValue(&powerupTime        , "cm_powerup_time"   , configFileVM, commandLineVM);
+  setParamValue(&sensorsThroughZynq , "sensorsThroughZynq", configFileVM, commandLineVM);
 
+//  // Read from configuration file and set up parameters
+//  syslog(LOG_INFO,"Reading from config file now\n");
+//
+//  // fileOptions is for parsing config files
+//  boost::program_options::options_description fileOptions{"File"};
+//  //sigh... with boost comes compilcated c++ magic
+//  fileOptions.add_options() 
+//    ("polltime", 
+//     boost::program_options::value<int>(),//->default_value(DEFAULT_POLLTIME_IN_SECONDS), 
+//     "polling interval")
+//    ("cm_powerup",
+//     boost::program_options::value<bool>(),//->default_value(true), 
+//     "power up CM uC")
+//    ("cm_powerup_time",
+//     boost::program_options::value<int>(),//->default_value(DEFAULT_POWERUP_TIME), 
+//     "uC powerup wait time")
+//    ("sensorsThroughZynq",
+//     boost::program_options::value<bool>(),//->default_value(DEFAULT_SENSORS_THROUGH_ZYNQ),
+//     "read sensor data through zynq");
+//
+//  boost::program_options::variables_map configOptions;  
+//  try{
+//    configOptions = loadConfig(configFile.getValue(),fileOptions);
+//    // Check for information in configOptions. If they exist set the corresponding "from_config" variable to true so that the command line default doesn't override what we have
+//    if(configOptions.count("polltime")) {
+//      polltime_in_seconds = configOptions["polltime"].as<int>();
+//      polltime_from_config = true;
+//    }  
+//    if(configOptions.count("cm_powerup")) {
+//      powerupCMuC = configOptions["cm_powerup"].as<bool>();
+//      powerupCMuc_from_config = true;
+//    }  
+//    if(configOptions.count("cm_powerup_time")) {
+//      powerupTime = configOptions["cm_powerup_time"].as<int>();
+//      powerupTime_from_config = true;
+//    }  
+//    if(configOptions.count("sensorsThroughZynq")) {
+//      sensorsThroughZynq = configOptions["sensorsThroughZynq"].as<bool>();
+//      sTZ_from_config = true;
+//    }
+//
+//  }catch(const boost::program_options::error &ex){
+//    syslog(LOG_INFO, "Caught exception in function loadConfig(): %s \n", ex.what());    
+//  }
+//  
+//  // ============================================================================
+//  // Parsing command line. Parameters set from the command line will override any parameters set from the config file above.
+//  
+//  syslog(LOG_INFO, "Reading from command line now\n");
+//
+//  // commandLineOptions is for parsing the command line
+//  boost::program_options::options_descriptions commandLineOptions{"Options"};
+//  //sigh... with boost comes compilcated c++ magic
+//  commandLineOptions.add_options() 
+//    ("polltime", 
+//     boost::program_options::value<int>()->default_value(DEFAULT_POLLTIME_IN_SECONDS), 
+//     "polling interval")
+//    ("cm_powerup",
+//     boost::program_options::value<bool>()->default_value(true), 
+//     "power up CM uC")
+//    ("cm_powerup_time",
+//     boost::program_options::value<int>()->default_value(DEFAULT_POWERUP_TIME), 
+//     "uC powerup wait time")
+//    ("sensorsThroughZynq",
+//     boost::program_options::value<bool>()->default_value(DEFAULT_SENSORS_THROUGH_ZYNQ),
+//     "read sensor data through zynq");
+//
+//  boost::program_options::variables_map commandLineVM;  
+//  try{
+//
+//    boost::program_options::store(boost::program_options::parse_command_line(argc, argv, commandLineOptions), commandLineVM);
+// 
+//    //    setParam(param, map, from_config);    
+////    setParam(&polltime_in_seconds, "polltime_in_seconds", commandLineVM, polltime_from_config);
+////    setParam(&powerupCMuC,       , "powerupCMuC",         commandLineVM, powerupCMuC_from_config);
+////    setParam(&powerupTime,       , "powerupTime",         commandLineVM, powerupTime_from_config);
+////    setParam(&sensorsThroughZynq , "sensorsThroughZynq",  commandLineVM, sTZ_from_config);
+//
+//    // Set polltime
+//    if(commandLineVM.count("polltime")) {
+//      // polltime exists, but was it defaulted?
+//      if(commandLineVM["polltime"].defaulted()) {
+//	// We have a defaulted polltime, but do we have a config option obtained from the config file?
+//	if(polltime_from_config) {
+//	  // We have a config option obtained from the config file. Do nothing
+//	  syslog(LOG_INFO, "Setting polltime to %d (CONFIG FILE)\n", polltime_in_seconds);
+//	} else {
+//	  // We do not have a config option obtained from the config file. Our default can be used.
+//	  polltime_in_seconds = commandLineVM["polltime"].as<int>();
+//	  syslog(LOG_INFO, "Setting polltime to %d (DEFAULT)\n", polltime_in_seconds);
+//	} 
+//      } else { 
+//	// We have a non-defaulted parameter option set from the command line! This trumps everything
+//	polltime_in_seconds = commandLineVM["polltime"].as<int>();
+//	syslog(LOG_INFO, "Setting polltime to %d (COMMAND LINE)\n", polltime_in_seconds);
+//      }
+//    }
+//
+//    // Set cm_powerup
+//    if(commandLineVM.count("cm_powerup")) {
+//      // cm_powerup exists, but was it defaulted?
+//      if(commandLineVM["cm_powerup"].defaulted()) {
+//	// We have a defaulted cm_powerup, but do we have a config option obtained from the config file?
+//	if(powerupCMuC_from_config) {
+//	  // We have a config option obtained from the config file. Do nothing
+//	  syslog(LOG_INFO, "Setting cm_powerup to %s (CONFIG FILE)\n", powerupCMuC ? "true" : "false");
+//	} else {
+//	  // We do not have a config option obtained from the config file. Our default can be used.
+//	  powerupCMuC = commandLineVM["cm_powerup"].as<bool>();
+//	  syslog(LOG_INFO, "Setting cm_powerup to %s (DEFAULT)\n", powerupCMuC ? "true" : "false");
+//	} 
+//      } else { 
+//	// We have a non-defaulted parameter option set from the command line! This trumps everything
+//	powerupCMuC = commandLineVM["cm_powerup"].as<bool>();
+//	syslog(LOG_INFO, "Setting cm_powerup to %s (COMMAND LINE)\n", powerupCMuC ? "true" : "false");
+//      }
+//    }
+//
+//    // Set cm_powerup_time
+//    if(commandLineVM.count("cm_powerup_time")) {
+//      // cm_powerup_time exists, but was it defaulted?
+//      if(commandLineVM["cm_powerup_time"].defaulted()) {
+//	// We have a defaulted cm_powerup_time, but do we have a config option obtained from the config file?
+//	if(powerupTime_from_config) {
+//	  // We have a config option obtained from the config file. Do nothing
+//	  syslog(LOG_INFO, "Setting cm_powerup_time to %d (CONFIG FILE)\n", powerupTime);
+//	} else {
+//	  // We do not have a config option obtained from the config file. Our default can be used.
+//	  powerupTime = commandLineVM["cm_powerup_time"].as<int>();
+//	  syslog(LOG_INFO, "Setting cm_powerup_time to %d (DEFAULT)\n", powerupTime);
+//	} 
+//      } else { 
+//	// We have a non-defaulted parameter option set from the command line! This trumps everything
+//	powerupTime = commandLineVM["cm_powerup_time"].as<int>();
+//	syslog(LOG_INFO, "Setting cm_powerup_time to %d (COMMAND LINE)\n", powerupTime);
+//      }
+//    }
+//
+//    // Set sensorsThroughZynq
+//    if(commandLineVM.count("sensorsThroughZynq")) {
+//      // sensorsThroughZynq exists, but was it defaulted?
+//      if(commandLineVM["sensorsThroughZynq"].defaulted()) {
+//	// We have a defaulted sensorsThroughZynq, but do we have a config option obtained from the config file?
+//	if(sTZ_from_config) {
+//	  // We have a config option obtained from the config file. Do nothing
+//	  syslog(LOG_INFO, "Setting sensorsThroughZynq to %s (CONFIG FILE)\n", sensorsThroughZynq ? "true" : "false");
+//	} else {
+//	  // We do not have a config option obtained from the config file. Our default can be used.
+//	  sensorsThroughZynq = commandLineVM["sensorsThroughZynq"].as<bool>();
+//	  syslog(LOG_INFO, "Setting sensorsThroughZynq to %s (DEFAULT)\n", sensorsThroughZynq ? "true" : "false");
+//	} 
+//      } else { 
+//	// We have a non-defaulted parameter option set from the command line! This trumps everything
+//	sensorsThroughZynq = commandLineVM["sensorsThroughZynq"].as<bool>();
+//	syslog(LOG_INFO, "Setting sensorsThroughZynq to %s (COMMAND LINE)\n", sensorsThroughZynq ? "true" : "false");
+//      }
+//    }
+//
+//  }catch(const boost::program_options::error &ex){
+//    syslog(LOG_INFO, "Caught exception while parsing command line: %s \n", ex.what());    
+//  }
+//
   // ============================================================================
   // Daemon code setup
 

--- a/src/standalone/SM_boot.cxx
+++ b/src/standalone/SM_boot.cxx
@@ -324,14 +324,15 @@ int main(int argc, char** argv) {
     // parse command line
     boost::program_options::store(boost::program_options::parse_command_line(argc, argv, commandLineOptions), commandLineVM);
   } catch(const boost::program_options::error &ex) {
-    fprintf(stderr, "Caught exception while parsing command line: %s \n", ex.what());        
+    fprintf(stderr, "Caught exception while parsing command line: %s \n", ex.what());       
+    exit(EXIT_FAILURE); 
   }
 
   // Check for non default config file
   if(commandLineVM.count("config_file")) {
     configFile = commandLineVM["config_file"].as<std::string>();
   }  
-  fprintf(stdout, "config file path: %s", configFile.c_str());
+  fprintf(stdout, "config file path: %s\n", configFile.c_str());
 
   // Now the config file may be loaded
   fprintf(stdout, "Reading from config file now\n");
@@ -340,9 +341,11 @@ int main(int argc, char** argv) {
     configFileVM = loadConfig(configFile, fileOptions);
   } catch(const boost::program_options::error &ex) {
     fprintf(stdout, "Caught exception in function loadConfig(): %s \n", ex.what());        
+    exit(EXIT_FAILURE);   
   }
 
   // Look at the config file and command line and see if we should change the parameters from their default values
+  // Only run path and pid file are needed for the next bit of code. The other parameters can and should wait until syslog is available.
   setParamValue(&runPath            , "run_path"          , configFileVM, commandLineVM, false);
   setParamValue(&pidFileName        , "pid_file"          , configFileVM, commandLineVM, false);
 //  setParamValue(&polltime_in_seconds, "polltime"          , configFileVM, commandLineVM, true);


### PR DESCRIPTION
can override smboot config file parameters from command line 