### PR TITLE
Network mon bugfix

### DIFF
--- a/src/ApolloSM/ApolloSM.cc
+++ b/src/ApolloSM/ApolloSM.cc
@@ -162,7 +162,9 @@ void ApolloSM::unblockAXI() {
   RegWriteAction("C2C1_AXI_FW.UNBLOCK");
   RegWriteAction("C2C1_AXILITE_FW.UNBLOCK");
   RegWriteAction("C2C2_AXI_FW.UNBLOCK");
-  RegWriteAction("C2C2_AXILITE_FW.UNBLOCK");  
+  RegWriteAction("C2C2_AXILITE_FW.UNBLOCK");
+  RegWriteAction("CM.CM_1.C2C.CNT.RESET_COUNTERS");
+  RegWriteAction("CM.CM_2.C2C.CNT.RESET_COUNTERS");
   return;
 }
 

--- a/src/standalone/lnxSysMon.cc
+++ b/src/standalone/lnxSysMon.cc
@@ -216,6 +216,10 @@ int networkMonitor(int &inRate, int &outRate){
   //Get rate of change
   if (time_diff != 0) { //Do not divide by 0
     inRate = InOctets_diff / time_diff;
-    outRate = OutOctets_diff / time_diff;}
+    outRate = OutOctets_diff / time_diff;
+  } else { //this should make it obvious in the charts that something went wrong
+    inRate = -1;
+    outRate = -1;
+  }
   return 0;
 }


### PR DESCRIPTION
network monitor now writes rates as -1 if an error occurs. unblockAXI command resets some error counters