### PR TITLE
Incorporate BUTextIO with StatusDisplay, replace printf

### DIFF
--- a/src/ApolloSM_device/ApolloSM_device.cc
+++ b/src/ApolloSM_device/ApolloSM_device.cc
@@ -248,9 +248,11 @@ CommandReturn::status ApolloSMDevice::CMPowerUP(std::vector<std::string> /*strAr
   }
   bool success = SM->PowerUpCM(CM_ID,wait_time);
   if(success){
-    printf("CM %d is powered up\n",CM_ID);
+    //printf("CM %d is powered up\n",CM_ID);
+    Print(level::INFO, "CM %d is powered up\n",CM_ID);
   }else{
-    printf("CM %d failed to powered up in time\n",CM_ID);
+    //printf("CM %d failed to powered up in time\n",CM_ID);
+    Print(level::INFO, "CM %d failed to powered up in time\n",CM_ID);
   }
   return CommandReturn::OK;
 }
@@ -274,9 +276,11 @@ CommandReturn::status ApolloSMDevice::CMPowerDown(std::vector<std::string> /*str
   }
   bool success = SM->PowerDownCM(CM_ID,wait_time);
   if(success){
-    printf("CM %d is powered down\n",CM_ID);
+    //printf("CM %d is powered down\n",CM_ID);
+    Print(Level::INFO, "CM %d is powered down\n", CM_ID);
   }else{
-    printf("CM %d failed to powered down in time (forced off)\n",CM_ID);
+    //printf("CM %d failed to powered down in time (forced off)\n",CM_ID);
+    Print(Level::INFO, "CM %d failed to powered down in time (forced off)\n", CM_ID);
   }
   return CommandReturn::OK;
 }
@@ -330,7 +334,8 @@ CommandReturn::status ApolloSMDevice::UART_CMD(std::vector<std::string> strArg,s
   //get rid of last space
   sendline.pop_back();
 
-  printf("Recieved:\n\n%s\n\n", (SM->UART_CMD(ttyDev, sendline,promptChar)).c_str());
+  //printf("Recieved:\n\n%s\n\n", (SM->UART_CMD(ttyDev, sendline,promptChar)).c_str());
+  Print(Level::INFO, "Recieved:\n\n%s\n\n", (SM->UART_CMD(ttyDev, sendline,promptChar)).c_str());
 
   return CommandReturn::OK;
 } 

--- a/src/ApolloSM_device/ApolloSM_device.cc
+++ b/src/ApolloSM_device/ApolloSM_device.cc
@@ -252,10 +252,10 @@ CommandReturn::status ApolloSMDevice::CMPowerUP(std::vector<std::string> /*strAr
   bool success = SM->PowerUpCM(CM_ID,wait_time);
   if(success){
     //printf("CM %d is powered up\n",CM_ID);
-    Print(level::INFO, "CM %d is powered up\n",CM_ID);
+    Print(Level::INFO, "CM %d is powered up\n",CM_ID);
   }else{
     //printf("CM %d failed to powered up in time\n",CM_ID);
-    Print(level::INFO, "CM %d failed to powered up in time\n",CM_ID);
+    Print(Level::INFO, "CM %d failed to powered up in time\n",CM_ID);
   }
   return CommandReturn::OK;
 }

--- a/src/ApolloSM_device/ApolloSM_device.cc
+++ b/src/ApolloSM_device/ApolloSM_device.cc
@@ -202,7 +202,10 @@ CommandReturn::status ApolloSMDevice::StatusDisplay(std::vector<std::string> str
       statusLevel = intArg[0];
       break;
     }
-  SM->GenerateStatusDisplay(statusLevel,std::cout,table);
+
+  std::ostringstream oss;
+  SM->GenerateStatusDisplay(statusLevel,oss,table);
+  Print(Level::INFO, "%s", oss.str().c_str());
   return CommandReturn::OK;
 }
 


### PR DESCRIPTION
Fix StatusDisplay by passing it an `ostringstream` instead of `cout`, then use BUTextIO to print the result. Also replace all `printf` calls in ApolloSMDevice with `Print()` statements from direct inheritance from BUTextIO.