### PR TITLE
Legacy UIOLabelFinder method fix

### DIFF
--- a/include/ApolloSM/uioLabelFinder.hh
+++ b/include/ApolloSM/uioLabelFinder.hh
@@ -32,18 +32,15 @@ uint64_t SearchDeviceTree(std::string const & dvtPath,std::string const & name){
   char label[128];
   // traverse through the device-tree   
   for (directory_iterator x(dvtPath); x!=directory_iterator(); ++x){
-    if (!is_directory(x->path()) ||
-	!exists(x->path()/"label")) {
-      continue;
-    }
-    labelfile = fopen((x->path().native()+"/label").c_str(),"r");
+    if (x->path().filename().native() != "label") { continue; }
+    labelfile = fopen((x->path().native()).c_str(),"r");
     fgets(label,128,labelfile);
     fclose(labelfile);
 
     if(!strcmp(label, name.c_str())){
       //Get endpoint AXI address from path           
       // looks something like LABEL@DEADBEEFXX       
-      std::string stringAddr=x->path().filename().native();
+      std::string stringAddr=x->path().parent_path().native();
 
       //Check if we find the @          
       size_t addrStart = stringAddr.find("@");
@@ -96,7 +93,7 @@ int label2uio_old(std::string ilabel)
       continue;
     }
     
-    if (!exists(itDir->path()/"label")) {
+    if (!exists(itDir->path().native()+"/label")) {
       //This directory does not contain a file named "label"
       continue;
     }

--- a/src/ApolloSM/svfplayer.cc
+++ b/src/ApolloSM/svfplayer.cc
@@ -159,6 +159,15 @@ int SVFPlayer::play(std::string const & svfFileName , std::string const & XVCLab
   tap_state = LIBXSVF_TAP_INIT;
 
   int nUIO = label2uio(XVCLabel);
+  // Fall back to the legacy method if we can't find anything
+  if (nUIO == -1) {
+    nUIO = label2uio_old(XVCLabel);
+  }
+
+  // If we still can't find anything, throw an exception
+  if (nUIO == -1) {
+    throw std::runtime_error("Failed to open UIO device");    
+  }
 
   size_t const uioFileNameLength = 1024;
   char * uioFileName = new char[uioFileNameLength+1];
@@ -168,9 +177,6 @@ int SVFPlayer::play(std::string const & svfFileName , std::string const & XVCLab
   //Run setup
   fdUIO = open(uioFileName,O_RDWR);
   delete [] uioFileName;
-  if (fdUIO < 0) {
-    throw std::runtime_error("Failed to open UIO device");    
-  }
   
   jtag_reg = (sXVC volatile*) mmap(NULL, sizeof(sXVC) + offset*sizeof(uint32_t),
 				    PROT_READ|PROT_WRITE, MAP_SHARED,

--- a/src/ApolloSM/svfplayer.cc
+++ b/src/ApolloSM/svfplayer.cc
@@ -166,7 +166,7 @@ int SVFPlayer::play(std::string const & svfFileName , std::string const & XVCLab
 
   // If we still can't find anything, throw an exception
   if (nUIO == -1) {
-    throw std::runtime_error("Failed to open UIO device");    
+    throw std::runtime_error("Failed to find a UIO device");    
   }
 
   size_t const uioFileNameLength = 1024;
@@ -177,6 +177,9 @@ int SVFPlayer::play(std::string const & svfFileName , std::string const & XVCLab
   //Run setup
   fdUIO = open(uioFileName,O_RDWR);
   delete [] uioFileName;
+  if (fdUIO < 0) {
+    throw std::runtime_error("Failed to open UIO device");    
+  }
   
   jtag_reg = (sXVC volatile*) mmap(NULL, sizeof(sXVC) + offset*sizeof(uint32_t),
 				    PROT_READ|PROT_WRITE, MAP_SHARED,


### PR DESCRIPTION
This PR contains a fix to the legacy `uio2label_old` method. During a call to `SVFPlayer::Play()`, first the more recent `label2uio` method is called, then if it doesn't find anything, a fallback to this legacy method is performed. If still nothing is found, an exception is thrown.