### PR TITLE
Fixes in GenerateHTMLStatus method

### DIFF
--- a/src/ApolloSM/ApolloSM.cc
+++ b/src/ApolloSM/ApolloSM.cc
@@ -40,7 +40,7 @@ std::string ApolloSM::GenerateHTMLStatus(std::string filename,
   if (type == "HTML") {statusDisplay.SetHTML();}
   else if(type == "Bare") {}
   else {
-    fprintf(stderr, "ERROR: invalid HTML type %s\n", type);
+    fprintf(stderr, "ERROR: invalid HTML type %s\n", type.c_str());
     fprintf(stderr, "Valid HTML types are; 'HTML', 'Bare', or '' for HTML\n");
     return "ERROR";
   }

--- a/src/ApolloSM/ApolloSM.cc
+++ b/src/ApolloSM/ApolloSM.cc
@@ -40,8 +40,8 @@ std::string ApolloSM::GenerateHTMLStatus(std::string filename,
   if (type == "HTML") {statusDisplay.SetHTML();}
   else if(type == "Bare") {}
   else {
-    fprintf(stderr, "ERROR: invalid HTML type\n");
-    fprintf(stderr, "Valid HTML types are; HTML, Bare, or "" for HTML\n");
+    fprintf(stderr, "ERROR: invalid HTML type %s\n", type);
+    fprintf(stderr, "Valid HTML types are; 'HTML', 'Bare', or '' for HTML\n");
     return "ERROR";
   }
 

--- a/src/ApolloSM_device/ApolloSM_device.cc
+++ b/src/ApolloSM_device/ApolloSM_device.cc
@@ -139,7 +139,7 @@ void ApolloSMDevice::LoadCommandList(){
   AddCommand("GenerateHTMLStatus",&ApolloSMDevice::GenerateHTMLStatus,
 	     "Creates a status table as an html file\n" \
 	     "Usage: \n" \
-	     "  GenerateHTMLStatus filename <level> <type>\n");
+	     "  GenerateHTMLStatus filename <type> <level>\n");
 
   AddCommand("uart_term",&ApolloSMDevice::UART_Term,
 	     "The function used for communicating with the command module uart\n"\

--- a/src/ApolloSM_device/ApolloSM_device.cc
+++ b/src/ApolloSM_device/ApolloSM_device.cc
@@ -394,27 +394,40 @@ CommandReturn::status ApolloSMDevice::svfplayer(std::vector<std::string> strArg,
   return CommandReturn::OK;
 }
 
-CommandReturn::status ApolloSMDevice::GenerateHTMLStatus(std::vector<std::string> strArg, std::vector<uint64_t> level) {
-  if (strArg.size() < 1) {
+CommandReturn::status ApolloSMDevice::GenerateHTMLStatus(std::vector<std::string> strArg, std::vector<uint64_t> intArg) {
+  size_t numArgs = strArg.size();
+  
+  // At least one command line argument is required for the filename
+  if (numArgs < 1) {
     return CommandReturn::BAD_ARGS;
   }
 
-  std::string strOut;
+  // The filename to save the HTML tables
+  std::string filename = strArg[0];
 
-  //Grab a possible level
-  size_t verbosity;
-  if (level.size() == 1) {
-    verbosity = level[0];
-  }else {
-    verbosity = 1;
+  // Grab a possible verbosity level (default is 1, least verbosity)
+  size_t verbosity = 1;
+
+  // HTML document type, default is full HTML (specified as "HTML")
+  std::string type = "HTML";
+
+  switch (numArgs) {
+    // Both the HTML type and verbosity are specified in the command line
+    case 3:
+      type = strArg[1];
+      verbosity = intArg[2];
+      break;
+    // Just the HTML type is specified
+    case 2:
+      type = strArg[1];
+      break;
   }
 
-  if (strArg.size() == 1) {
-    strOut = SM->GenerateHTMLStatus(strArg[0],verbosity,"HTML");
-  }else{
-    strOut = SM->GenerateHTMLStatus(strArg[0],verbosity,strArg[1]);
-  }
+  // Call the dedicated function of ApolloSM class to generate the HTML table
+  // and return a string
+  std::string strOut = SM->GenerateHTMLStatus(filename,verbosity,type);
 
+  // Something has gone wrong while generating the table
   if (strOut == "ERROR") {
     return CommandReturn::BAD_ARGS;
   }


### PR DESCRIPTION
This PR contains several fixes to the `GenerateHTMLStatus` method of `ApolloSMDevice` class. The help message is updated, and the bug related to the `statusLevel` argument not working properly is fixed.