### PR TITLE
Fix the syntax error in handle_eof task

### DIFF
--- a/src/ApolloSM/svfplayer_svf.cc
+++ b/src/ApolloSM/svfplayer_svf.cc
@@ -45,8 +45,8 @@ int SVFPlayer::read_command(char **buffer_p, int *len_p)
       handle_eof:
 	if (p == 0)
 	  return 0;
-	  textIO->Print(Level::ERROR, "Unexpected EOF.\n");
-	  return -1;
+	textIO->Print(Level::ERROR, "Unexpected EOF.\n");
+	return -1;
       }
       if (ch <= ' ') {
       insert_eol:


### PR DESCRIPTION
This PR fixes the syntax error under the definition of `handle_eof` task, under `svfplayer_svf.cc`.