### PR TITLE
Configure several daemons to use SM-only address table

### DIFF
--- a/src/standalone/SM_boot.cxx
+++ b/src/standalone/SM_boot.cxx
@@ -31,6 +31,7 @@
 // Set up for boost program_options
 #define DEFAULT_CONFIG_FILE "/etc/SM_boot"
 #define DEFAULT_POLLTIME_IN_SECONDS 10
+#define DEFAULT_CONN_FILE   "/fw/SM/address_table/connections.xml"
 #define DEFAULT_RUN_DIR     "/opt/address_table/"
 #define DEFAULT_PID_FILE    "/var/run/sm_boot.pid"
 #define DEFAULT_POWERUP_TIME 5
@@ -190,12 +191,13 @@ bool isNumber(std::string const & str){
 int main(int argc, char** argv) { 
 
   // parameters to get from command line or config file (config file itself will not be in the config file, obviously)
-  std::string runPath     = DEFAULT_RUN_DIR;
-  std::string pidFileName = DEFAULT_PID_FILE;
-  int polltime_in_seconds = DEFAULT_POLLTIME_IN_SECONDS;
-  bool powerupCMuC        = DEFAULT_CM_POWERUP;
-  int powerupTime         = DEFAULT_POWERUP_TIME;
-  bool sensorsThroughZynq = DEFAULT_SENSORS_THROUGH_ZYNQ;
+  std::string runPath        = DEFAULT_RUN_DIR;
+  std::string pidFileName    = DEFAULT_PID_FILE;
+  std::string connectionFile = DEFAULT_CONN_FILE;
+  int polltime_in_seconds    = DEFAULT_POLLTIME_IN_SECONDS;
+  bool powerupCMuC           = DEFAULT_CM_POWERUP;
+  int powerupTime            = DEFAULT_POWERUP_TIME;
+  bool sensorsThroughZynq    = DEFAULT_SENSORS_THROUGH_ZYNQ;
 
   //Mikey - finish
   po::options_description cli_options("SM_boot options");
@@ -204,6 +206,7 @@ int main(int argc, char** argv) {
     ("run_path,r",           po::value<std::string>(), "Path to run directory")
     ("pid_file,f",           po::value<std::string>(), "pid file")
     ("polltime,P",           po::value<int>(),         "Polltime in seconds")
+    ("conn_file,c",          po::value<std::string>(), "Path to the default connections file")
     ("cm_powerup,P",         po::value<bool>(),        "Powerup CM")
     ("cm_powerup_time,t",    po::value<int>(),         "Powerup time in seconds")
     ("sensorsThroughZynq,s", po::value<bool>(),        "Read sensors through the Zynq")
@@ -215,6 +218,7 @@ int main(int argc, char** argv) {
     ("run_path",           po::value<std::string>(), "Path to run directory")
     ("pid_file",           po::value<std::string>(), "pid file")
     ("polltime",           po::value<int>(),         "Polltime in seconds")
+    ("conn_file",          po::value<std::string>(), "Path to the default connections file")
     ("cm_powerup",         po::value<bool>(),        "Powerup CM")
     ("cm_powerup_time",    po::value<int>(),         "Powerup time in seconds")
     ("regwrite,w",         po::value<std::string>(), "Reg write to perform on boot")
@@ -253,6 +257,7 @@ int main(int argc, char** argv) {
   
   runPath=             GetFinalParameterValue(std::string("run_path"),          allOptions,std::string(DEFAULT_RUN_DIR));
   pidFileName=         GetFinalParameterValue(std::string("pid_file"),          allOptions,std::string(DEFAULT_PID_FILE));
+  connectionFile=      GetFinalParameterValue(std::string("conn_file"),         allOptions,std::string(DEFAULT_CONN_FILE));
   polltime_in_seconds= GetFinalParameterValue(std::string("polltime"),          allOptions,DEFAULT_POLLTIME_IN_SECONDS);
   powerupCMuC=         GetFinalParameterValue(std::string("cm_powerup"),        allOptions,DEFAULT_CM_POWERUP);
   powerupTime=         GetFinalParameterValue(std::string("cm_powerup_time"),   allOptions,DEFAULT_POWERUP_TIME);
@@ -286,7 +291,7 @@ int main(int argc, char** argv) {
     // ==================================
     // Initialize ApolloSM
     std::vector<std::string> arg;
-    arg.push_back("connections.xml");
+    arg.push_back(connectionFile);
     
     SM = new ApolloSM(arg);
     if(NULL == SM){

--- a/src/standalone/SM_boot.cxx
+++ b/src/standalone/SM_boot.cxx
@@ -290,6 +290,7 @@ int main(int argc, char** argv) {
   try{
     // ==================================
     // Initialize ApolloSM
+    syslog(LOG_INFO,"Using connections file: %s\n", connectionFile.c_str());      
     std::vector<std::string> arg;
     arg.push_back(connectionFile);
     

--- a/src/standalone/heartbeat.cxx
+++ b/src/standalone/heartbeat.cxx
@@ -145,6 +145,7 @@ int main(int argc, char** argv) {
   //=======================================================================
   ApolloSM * SM = NULL;
   try{
+    syslog(LOG_INFO,"Using connections file: %s\n", connectionFile.c_str());      
     // ==================================
     // Initialize ApolloSM
     std::vector<std::string> arg;

--- a/src/standalone/heartbeat.cxx
+++ b/src/standalone/heartbeat.cxx
@@ -29,9 +29,10 @@
 #define DEFAULT_CONFIG_FILE "/etc/heartbeat"
 
 #define DEFAULT_POLLTIME_IN_SECONDS 10
-#define DEFAULT_CONN_FILE "/opt/address_table/connections.xml"
 #define DEFAULT_RUN_DIR "/opt/address_table/"
 #define DEFAULT_PID_FILE "/var/run/heartbeat.pid"
+#define DEFAULT_CONN_FILE "/fw/SM/address_table/connections.xml"
+
 namespace po = boost::program_options;
 
 
@@ -147,7 +148,7 @@ int main(int argc, char** argv) {
     // ==================================
     // Initialize ApolloSM
     std::vector<std::string> arg;
-    arg.push_back("connections.xml");
+    arg.push_back(connectionFile);
     SM = new ApolloSM(arg);
     if(NULL == SM){
       syslog(LOG_ERR,"Failed to create new ApolloSM\n");

--- a/src/standalone/i2c_write_monitor.cxx
+++ b/src/standalone/i2c_write_monitor.cxx
@@ -31,7 +31,7 @@
 // Define defaults for the daemon
 #define DEFAULT_POLLTIME_IN_SECONDS 1
 #define DEFAULT_TIMEOUT_IN_SECONDS 60
-#define DEFAULT_CONN_FILE "/opt/address_table/connections.xml"
+#define DEFAULT_CONN_FILE "/fw/SM/address_table/connections.xml"
 #define DEFAULT_RUN_DIR "/opt/address_table/"
 #define DEFAULT_PID_FILE "/var/run/i2c_write_monitor.pid"
 
@@ -172,9 +172,14 @@ int main(int argc, char** argv) {
     // Set up ApolloSM instance
     ApolloSM * SM = NULL;
     try {
+        syslog(LOG_INFO, "Starting I2C write monitor\n");
+        syslog(LOG_INFO, "Using connection file: %s\n", connectionFile.c_str());
+        syslog(LOG_INFO, "Setting timeout to: %u seconds\n", timeout_in_seconds);
+        syslog(LOG_INFO, "Will poll %s every %u seconds\n", registerName.c_str(), polltime_in_seconds);
+
         // Initialize ApolloSM
         std::vector<std::string> arg;
-        arg.push_back("connections.xml");
+        arg.push_back(connectionFile);
         SM = new ApolloSM(arg);
         
         // Check if we failed to allocate an ApolloSM
@@ -188,7 +193,6 @@ int main(int argc, char** argv) {
         /*
          * Go into the main daemon loop.
          */
-        syslog(LOG_INFO,"Starting I2C write monitor\n");
 
         // Get initial time
         clock_gettime(CLOCK_REALTIME, &daemonStartTS);

--- a/src/standalone/ps_monitor.cxx
+++ b/src/standalone/ps_monitor.cxx
@@ -153,6 +153,7 @@ int main(int argc, char ** argv) {
   try{
     // ==================================
     // Initialize ApolloSM
+    syslog(LOG_INFO,"Using connections file: %s\n", connectionFile.c_str());      
     std::vector<std::string> arg;
     arg.push_back(connectionFile);
     SM = new ApolloSM(arg);

--- a/src/standalone/ps_monitor.cxx
+++ b/src/standalone/ps_monitor.cxx
@@ -42,6 +42,8 @@
 #define DEFAULT_POLLTIME_IN_SECONDS 10
 #define DEFAULT_RUN_DIR "/opt/address_table"
 #define DEFAULT_PID_FILE "/var/run/ps_monitor.pid"
+#define DEFAULT_CONN_FILE "/fw/SM/address_table/connections.xml"
+
 namespace po = boost::program_options;
 
 
@@ -65,6 +67,7 @@ int main(int argc, char ** argv) {
     ("help,h",    "Help screen")
     ("POLLTIME_IN_SECONDS,s", po::value<int>(),         "polltime in seconds")
     ("RUN_DIR,r",             po::value<std::string>(), "run path")
+    ("CONN_FILE,c",           po::value<std::string>(), "Path to the XML connections file")
     ("PID_FILE,d",            po::value<std::string>(), "pid file")
     ("config_file",           po::value<std::string>(), "config file");
 
@@ -74,6 +77,7 @@ int main(int argc, char ** argv) {
   cfg_options.add_options()
     ("POLLTIME_IN_SECONDS", po::value<int>(),         "polltime in seconds")
     ("RUN_DIR",             po::value<std::string>(), "run path")
+    ("CONN_FILE",           po::value<std::string>(), "Path to the XML connections file")
     ("PID_FILE",            po::value<std::string>(), "pid file");
 
 
@@ -115,6 +119,8 @@ int main(int argc, char ** argv) {
   std::string runPath     = GetFinalParameterValue(std::string("RUN_DIR"),             allOptions, std::string(DEFAULT_RUN_DIR));
   //set pidFileName
   std::string pidFileName = GetFinalParameterValue(std::string("PID_FILE"),            allOptions, std::string(DEFAULT_PID_FILE));
+  // Get XML connection file for ApolloSM
+  std::string connectionFile = GetFinalParameterValue(std::string("CONN_FILE"),        allOptions, std::string(DEFAULT_CONN_FILE));
 
   // ============================================================================
   // Deamon book-keeping
@@ -148,7 +154,7 @@ int main(int argc, char ** argv) {
     // ==================================
     // Initialize ApolloSM
     std::vector<std::string> arg;
-    arg.push_back("connections.xml");
+    arg.push_back(connectionFile);
     SM = new ApolloSM(arg);
     if(NULL == SM){
       syslog(LOG_ERR,"Failed to create new ApolloSM\n");

--- a/src/standalone/pwr_monitor.cxx
+++ b/src/standalone/pwr_monitor.cxx
@@ -266,6 +266,7 @@ int main(int argc, char ** argv) {
   try{
     // ==================================
     // Initialize ApolloSM
+    syslog(LOG_INFO,"Using connections file: %s\n", connectionFile.c_str());      
     std::vector<std::string> arg;
     arg.push_back(connectionFile);
     SM = new ApolloSM(arg);

--- a/src/standalone/pwr_monitor.cxx
+++ b/src/standalone/pwr_monitor.cxx
@@ -122,6 +122,8 @@ void UpdateINA3221Sensor(ApolloSM * sm,
 #define DEFAULT_POLLTIME_IN_SECONDS 10
 #define DEFAULT_RUN_DIR "/opt/address_table"
 #define DEFAULT_PID_FILE "/var/run/pwr_monitor.pid"
+#define DEFAULT_CONN_FILE "/fw/SM/address_table/connections.xml"
+
 namespace po = boost::program_options;
 
 
@@ -143,6 +145,7 @@ int main(int argc, char ** argv) {
     ("help,h",    "Help screen")
     ("POLLTIME_IN_SECONDS,s", po::value<int>(),         "polltime in seconds")
     ("RUN_DIR,r",             po::value<std::string>(), "run path")
+    ("CONN_FILE,c",           po::value<std::string>(), "Path to the XML connections file")
     ("PID_FILE,d",            po::value<std::string>(), "pid file")
     ("config_file",           po::value<std::string>(), "config file");
 
@@ -152,6 +155,7 @@ int main(int argc, char ** argv) {
   cfg_options.add_options()
     ("POLLTIME_IN_SECONDS", po::value<int>(),         "polltime in seconds")
     ("RUN_DIR",             po::value<std::string>(), "run path")
+    ("CONN_FILE",           po::value<std::string>(), "Path to the XML connections file")
     ("PID_FILE",            po::value<std::string>(), "pid file")
     ("SESNOR_NAME",            po::value<std::string>(), "Sensor to read out")
     ("TABLE_PATH_ROOT",            po::value<std::string>(), "Address table path");
@@ -195,7 +199,9 @@ int main(int argc, char ** argv) {
   std::string runPath     = GetFinalParameterValue(std::string("RUN_DIR"),             allOptions, std::string(DEFAULT_RUN_DIR));
   //set pidFileName
   std::string pidFileName = GetFinalParameterValue(std::string("PID_FILE"),            allOptions, std::string(DEFAULT_PID_FILE));
-  
+  // Get XML connection file for ApolloSM
+  std::string connectionFile = GetFinalParameterValue(std::string("CONN_FILE"),        allOptions, std::string(DEFAULT_CONN_FILE));
+
   // ============================================================================
   // Deamon book-keeping
   Daemon daemon;
@@ -261,7 +267,7 @@ int main(int argc, char ** argv) {
     // ==================================
     // Initialize ApolloSM
     std::vector<std::string> arg;
-    arg.push_back("connections.xml");
+    arg.push_back(connectionFile);
     SM = new ApolloSM(arg);
     if(NULL == SM){
       syslog(LOG_ERR,"Failed to create new ApolloSM\n");

--- a/src/standalone/xvc_server.cxx
+++ b/src/standalone/xvc_server.cxx
@@ -52,6 +52,8 @@
 #define DEFAULT_PID_DIR "/var/run/"
 #define DEFAULT_XVCPREFIX " "
 #define DEFAULT_XVCPORT -1
+#define DEFAULT_CONN_FILE "/fw/SM/address_table/connections.xml"
+
 namespace po = boost::program_options;
 
 
@@ -233,14 +235,17 @@ int main(int argc, char **argv) {
     ("help,h",    "Help screen")
     ("RUN_DIR,r",   po::value<std::string>(), "Path to default run directory")
     ("PID_FILE,d",  po::value<std::string>(), "Path to default pid directory")
+    ("CONN_FILE,c", po::value<std::string>(), "Path to the XML connections file")
     ("xvcPrefix,v", po::value<std::string>(), "xvc prefix")
     ("xvcPort,p",   po::value<int>(),         "xvc_port number")
     ("config_file", po::value<std::string>(), "config file");
+  
   //Config File options
   po::options_description cfg_options("XVC options");
   cfg_options.add_options()
     ("RUN_DIR",   po::value<std::string>(), "Path to default run directory")
     ("PID_DIR",   po::value<std::string>(), "Path to default pid directory")
+    ("CONN_FILE", po::value<std::string>(), "Path to the XML connections file")
     ("xvcPrefix", po::value<std::string>(), "xvc prefix")
     ("xvcPort",   po::value<int>(),         "xvc_port number");
 
@@ -283,6 +288,8 @@ int main(int argc, char **argv) {
   std::string PID_DIR = GetFinalParameterValue(std::string("PID_DIR"),  allOptions,std::string(DEFAULT_PID_DIR));
   //Set RUN_DIR
   std::string RUN_DIR = GetFinalParameterValue(std::string("RUN_DIR"),  allOptions,std::string(DEFAULT_RUN_DIR));
+  // Get XML connection file for ApolloSM
+  std::string connectionFile = GetFinalParameterValue(std::string("CONN_FILE"), allOptions, std::string(DEFAULT_CONN_FILE));
 
   //use xvcName to get uiLabel
   std::string uioLabel = xvcName;
@@ -325,7 +332,7 @@ int main(int argc, char **argv) {
 
   //Getting offset
   std::vector<std::string> arg;
-  arg.push_back("connections.xml");
+  arg.push_back(connectionFile);
   ApolloSM * SM = new ApolloSM(arg);
   if(NULL == SM){
     syslog(LOG_ERR,"Failed to create new ApolloSM\n");

--- a/src/standalone/xvc_server.cxx
+++ b/src/standalone/xvc_server.cxx
@@ -331,6 +331,7 @@ int main(int argc, char **argv) {
   }
 
   //Getting offset
+  syslog(LOG_INFO,"Using connections file: %s\n", connectionFile.c_str());      
   std::vector<std::string> arg;
   arg.push_back(connectionFile);
   ApolloSM * SM = new ApolloSM(arg);


### PR DESCRIPTION
This PR configures several standalone ApolloSM daemons to use the SM-only address table (given that they are not using CM related registers). These services are:

* SM_boot
* ps_monitor
* pwr_monitor
* heartbeat
* i2c_write_monitor
* xvc_server

The necessary configuration files for these daemons are being added to the Zynq filesystem in [!15](https://gitlab.com/apollo-lhc/soc-os/-/merge_requests/15). FYI @dgastler, I'm aiming to test this on a blade soon.