### PR TITLE
Read the SHELF_ID register as a string

### DIFF
--- a/include/ApolloSM/ApolloSM.hh
+++ b/include/ApolloSM/ApolloSM.hh
@@ -45,8 +45,8 @@ public:
 
   int GetSerialNumber();
   int GetRevNumber();
-  int GetShelfID();
   int GetSlot();
+  std::string GetShelfID();
   uint32_t GetZynqIP();
   uint32_t GetIPMCIP();
 

--- a/src/ApolloSM/ApolloSM_info.cc
+++ b/src/ApolloSM/ApolloSM_info.cc
@@ -20,12 +20,12 @@ int ApolloSM::GetRevNumber(){
   }
   return ret;
 };
-int ApolloSM::GetShelfID(){
-  int ret = -1; //default value
+std::string ApolloSM::GetShelfID(){
+  std::string ret = ""; //default value
   try{
-    ret = ReadRegister("SLAVE_I2C.S1.SM.INFO.SLOT");
+    ret = ReadString("SLAVE_I2C.S6.SHELF_ID");
   }catch(BUException::BAD_REG_NAME & e2){
-    //eat this exception and just return -1;
+    //eat this exception and just return an empty string
   }
   return ret;
 };


### PR DESCRIPTION
Update the `GetShelfID` function of `ApolloSM` class such that it reads the proper register and returns a string.