### PR TITLE
Fix the runtime paths of the SM-only services to be /fw/SM/address_table

### DIFF
--- a/src/standalone/SM_boot.cxx
+++ b/src/standalone/SM_boot.cxx
@@ -32,7 +32,7 @@
 #define DEFAULT_CONFIG_FILE "/etc/SM_boot"
 #define DEFAULT_POLLTIME_IN_SECONDS 10
 #define DEFAULT_CONN_FILE   "/fw/SM/address_table/connections.xml"
-#define DEFAULT_RUN_DIR     "/opt/address_table/"
+#define DEFAULT_RUN_DIR     "/fw/SM/address_table"
 #define DEFAULT_PID_FILE    "/var/run/sm_boot.pid"
 #define DEFAULT_POWERUP_TIME 5
 #define DEFAULT_SENSORS_THROUGH_ZYNQ false // This means: by default, read the sensors through the zynq

--- a/src/standalone/heartbeat.cxx
+++ b/src/standalone/heartbeat.cxx
@@ -29,7 +29,7 @@
 #define DEFAULT_CONFIG_FILE "/etc/heartbeat"
 
 #define DEFAULT_POLLTIME_IN_SECONDS 10
-#define DEFAULT_RUN_DIR "/opt/address_table/"
+#define DEFAULT_RUN_DIR "/fw/SM/address_table"
 #define DEFAULT_PID_FILE "/var/run/heartbeat.pid"
 #define DEFAULT_CONN_FILE "/fw/SM/address_table/connections.xml"
 

--- a/src/standalone/i2c_write_monitor.cxx
+++ b/src/standalone/i2c_write_monitor.cxx
@@ -32,7 +32,7 @@
 #define DEFAULT_POLLTIME_IN_SECONDS 1
 #define DEFAULT_TIMEOUT_IN_SECONDS 60
 #define DEFAULT_CONN_FILE "/fw/SM/address_table/connections.xml"
-#define DEFAULT_RUN_DIR "/opt/address_table/"
+#define DEFAULT_RUN_DIR "/fw/SM/address_table"
 #define DEFAULT_PID_FILE "/var/run/i2c_write_monitor.pid"
 
 // Register name to read for the I2C write check

--- a/src/standalone/ps_monitor.cxx
+++ b/src/standalone/ps_monitor.cxx
@@ -40,7 +40,7 @@
 #define DEFAULT_CONFIG_FILE "/etc/ps_monitor"
 
 #define DEFAULT_POLLTIME_IN_SECONDS 10
-#define DEFAULT_RUN_DIR "/opt/address_table"
+#define DEFAULT_RUN_DIR "/fw/SM/address_table"
 #define DEFAULT_PID_FILE "/var/run/ps_monitor.pid"
 #define DEFAULT_CONN_FILE "/fw/SM/address_table/connections.xml"
 

--- a/src/standalone/pwr_monitor.cxx
+++ b/src/standalone/pwr_monitor.cxx
@@ -120,7 +120,7 @@ void UpdateINA3221Sensor(ApolloSM * sm,
 #define DEFAULT_CONFIG_FILE "/etc/pwr_monitor"
 
 #define DEFAULT_POLLTIME_IN_SECONDS 10
-#define DEFAULT_RUN_DIR "/opt/address_table"
+#define DEFAULT_RUN_DIR "/fw/SM/address_table"
 #define DEFAULT_PID_FILE "/var/run/pwr_monitor.pid"
 #define DEFAULT_CONN_FILE "/fw/SM/address_table/connections.xml"
 

--- a/src/standalone/xvc_server.cxx
+++ b/src/standalone/xvc_server.cxx
@@ -48,7 +48,7 @@
 // ================================================================================
 // Setup for boost program_options
 #define DEFAULT_CONFIG_FILE "/etc/xvc_server"
-#define DEFAULT_RUN_DIR "/opt/address_table/"
+#define DEFAULT_RUN_DIR "/fw/SM/address_table"
 #define DEFAULT_PID_DIR "/var/run/"
 #define DEFAULT_XVCPREFIX " "
 #define DEFAULT_XVCPORT -1


### PR DESCRIPTION
This PR updates the default runtime path of SM-only services to be `/fw/SM/address_table`.