### PR TITLE
Update I2C monitor service to pass on to other services if there is an exception 

### DIFF
--- a/src/standalone/i2c_write_monitor.cxx
+++ b/src/standalone/i2c_write_monitor.cxx
@@ -253,7 +253,7 @@ int main(int argc, char** argv) {
 
         // Loop around and do nothing
         while (daemon.GetLoop()) {
-            usleep(sleep_us);
+            usleep(60 * SEC_IN_US);
         }
 
     } catch (std::exception const & e) {
@@ -263,7 +263,7 @@ int main(int argc, char** argv) {
         
         // Loop around and do nothing
         while (daemon.GetLoop()) {
-            usleep(sleep_us);
+            usleep(60 * SEC_IN_US);
         }
     }
 

--- a/src/standalone/i2c_write_monitor.cxx
+++ b/src/standalone/i2c_write_monitor.cxx
@@ -248,7 +248,7 @@ int main(int argc, char** argv) {
      */
     } catch (BUException::exBase const & e) {
         syslog(LOG_WARNING,"Caught BUException: %s\n   Info: %s\n",e.what(),e.Description());          
-        syslog(LOG_WARNING,"Notifying systemd READY=1\n");          
+        syslog(LOG_INFO,"Notifying systemd READY=1\n");          
         sd_notify(0, "READY=1");
 
         // Loop around and do nothing
@@ -257,8 +257,8 @@ int main(int argc, char** argv) {
         }
 
     } catch (std::exception const & e) {
-        syslog(LOG_ERR,"Caught std::exception: %s\n",e.what());          
-        syslog(LOG_WARNING,"Notifying systemd READY=1\n");          
+        syslog(LOG_WARNING,"Caught std::exception: %s\n",e.what());          
+        syslog(LOG_INFO,"Notifying systemd READY=1\n");          
         sd_notify(0, "READY=1");
         
         // Loop around and do nothing


### PR DESCRIPTION
I2C write monitor service is updated so that if an exception is caught, `systemd` will be notified as ready and the boot sequence will continue. 